### PR TITLE
feat: Initial implementation of TDMS# library

### DIFF
--- a/TDMSSharp.Tests/TDMSSharp.Tests.csproj
+++ b/TDMSSharp.Tests/TDMSSharp.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TDMSSharp\TDMSSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TDMSSharp.Tests/WriterTests.cs
+++ b/TDMSSharp.Tests/WriterTests.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using Xunit;
+
+namespace TDMSSharp.Tests
+{
+    public class WriterTests
+    {
+        [Fact]
+        public void WriteAndRead_SimpleFile_MetadataShouldMatch()
+        {
+            // Arrange
+            var file = new TdmsFile();
+            file.AddProperty("Author", "Jules");
+            var group = file.GetOrAddChannelGroup("Test Group");
+            var channel = group.AddChannel<int>("Test Channel");
+            channel.AddProperty("Unit", "m/s");
+            var data = new int[] { 1, 2, 3, 4, 5 };
+            channel.AppendData(data);
+
+            // Act
+            using var stream = new MemoryStream();
+            file.Save(stream); // Using the public API Save method which now needs to support streams
+
+            stream.Position = 0;
+
+            var readFile = TdmsFile.Open(stream); // Using the public API Open method
+
+            // Assert
+            Assert.NotNull(readFile);
+            Assert.Single(readFile.Properties);
+            Assert.Equal("Jules", (string)readFile.Properties[0].Value);
+
+            Assert.Single(readFile.ChannelGroups);
+            var readGroup = readFile.ChannelGroups[0];
+            Assert.Equal("/'Test Group'", readGroup.Path);
+
+            Assert.Single(readGroup.Channels);
+            var readChannel = readGroup.Channels[0];
+            Assert.Equal("/'Test Group'/'Test Channel'", readChannel.Path);
+            Assert.Equal(TdsDataType.I32, readChannel.DataType);
+            Assert.Equal((ulong)data.Length, readChannel.NumberOfValues);
+
+            Assert.Single(readChannel.Properties);
+            Assert.Equal("Unit", readChannel.Properties[0].Name);
+            Assert.Equal("m/s", (string)readChannel.Properties[0].Value);
+        }
+    }
+}

--- a/TDMSSharp.sln
+++ b/TDMSSharp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDMSSharp", "TDMSSharp\TDMSSharp.csproj", "{ED030551-4B98-445F-A160-5C1641372D65}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDMSSharp.Tests", "TDMSSharp.Tests\TDMSSharp.Tests.csproj", "{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,18 @@ Global
 		{ED030551-4B98-445F-A160-5C1641372D65}.Release|x64.Build.0 = Release|Any CPU
 		{ED030551-4B98-445F-A160-5C1641372D65}.Release|x86.ActiveCfg = Release|Any CPU
 		{ED030551-4B98-445F-A160-5C1641372D65}.Release|x86.Build.0 = Release|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Release|x64.Build.0 = Release|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E1484E0-8A42-4431-B822-2C1CEF2C63FF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TDMSSharp/Class1.cs
+++ b/TDMSSharp/Class1.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace TDMSSharp
-{
-    public class Class1
-    {
-
-    }
-}

--- a/TDMSSharp/TdmsChannel.Generic.cs
+++ b/TDMSSharp/TdmsChannel.Generic.cs
@@ -1,0 +1,32 @@
+namespace TDMSSharp
+{
+    public class TdmsChannel<T> : TdmsChannel
+    {
+        public new T[] Data
+        {
+            get => (T[])base.Data;
+            set => base.Data = value;
+        }
+
+        public TdmsChannel(string path) : base(path)
+        {
+            DataType = TdsDataTypeProvider.GetDataType<T>();
+        }
+
+        public void AppendData(T[] dataToAppend)
+        {
+            if (Data == null)
+            {
+                Data = dataToAppend;
+            }
+            else
+            {
+                var newData = new T[Data.Length + dataToAppend.Length];
+                Data.CopyTo(newData, 0);
+                dataToAppend.CopyTo(newData, Data.Length);
+                Data = newData;
+            }
+            NumberOfValues = (ulong)Data.Length;
+        }
+    }
+}

--- a/TDMSSharp/TdmsChannel.cs
+++ b/TDMSSharp/TdmsChannel.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace TDMSSharp
+{
+    public class TdmsChannel
+    {
+        public string Path { get; }
+        public IList<TdmsProperty> Properties { get; } = new List<TdmsProperty>();
+        public TdsDataType DataType { get; set; }
+        public ulong NumberOfValues { get; set; }
+        public object Data { get; set; }
+
+        public TdmsChannel(string path)
+        {
+            Path = path;
+        }
+
+        public void AddProperty<T>(string name, T value)
+        {
+            var dataType = TdsDataTypeProvider.GetDataType<T>();
+            Properties.Add(new TdmsProperty(name, dataType, value));
+        }
+    }
+}

--- a/TDMSSharp/TdmsChannelGroup.cs
+++ b/TDMSSharp/TdmsChannelGroup.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TDMSSharp
+{
+    public class TdmsChannelGroup
+    {
+        public string Path { get; }
+        public IList<TdmsProperty> Properties { get; } = new List<TdmsProperty>();
+        public IList<TdmsChannel> Channels { get; } = new List<TdmsChannel>();
+
+        public TdmsChannelGroup(string path)
+        {
+            Path = path;
+        }
+
+        public TdmsChannel GetOrAddChannel(string path)
+        {
+            var channel = Channels.FirstOrDefault(c => c.Path == path);
+            if (channel == null)
+            {
+                channel = new TdmsChannel(path);
+                Channels.Add(channel);
+            }
+            return channel;
+        }
+
+        public TdmsChannel<T> AddChannel<T>(string name)
+        {
+            var channelName = name.Replace("'", "''");
+            var channelPath = $"{Path}/'{channelName}'";
+            if (Channels.Any(c => c.Path == channelPath))
+            {
+                throw new InvalidOperationException($"A channel with the name '{name}' already exists in this group.");
+            }
+
+            var channel = new TdmsChannel<T>(channelPath);
+            Channels.Add(channel);
+            return channel;
+        }
+
+        public void AddProperty<T>(string name, T value)
+        {
+            var dataType = TdsDataTypeProvider.GetDataType<T>();
+            Properties.Add(new TdmsProperty(name, dataType, value));
+        }
+    }
+}

--- a/TDMSSharp/TdmsFile.cs
+++ b/TDMSSharp/TdmsFile.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace TDMSSharp
+{
+    public class TdmsFile
+    {
+        public IList<TdmsProperty> Properties { get; } = new List<TdmsProperty>();
+        public IList<TdmsChannelGroup> ChannelGroups { get; } = new List<TdmsChannelGroup>();
+
+        public TdmsFile()
+        {
+        }
+
+        public TdmsChannelGroup GetOrAddChannelGroup(string name)
+        {
+            var path = $"/'{name.Replace("'", "''")}'";
+            var group = ChannelGroups.FirstOrDefault(g => g.Path == path);
+            if (group == null)
+            {
+                group = new TdmsChannelGroup(path);
+                ChannelGroups.Add(group);
+            }
+            return group;
+        }
+
+        public void AddProperty<T>(string name, T value)
+        {
+            var dataType = TdsDataTypeProvider.GetDataType<T>();
+            Properties.Add(new TdmsProperty(name, dataType, value));
+        }
+
+        public void Save(string path)
+        {
+            using (var stream = File.Create(path))
+            {
+                Save(stream);
+            }
+        }
+
+        public void Save(Stream stream)
+        {
+            var writer = new TdmsWriter(stream);
+            writer.WriteFile(this);
+        }
+
+        public static TdmsFile Open(string path)
+        {
+            using (var stream = File.OpenRead(path))
+            {
+                return Open(stream);
+            }
+        }
+
+        public static TdmsFile Open(Stream stream)
+        {
+            var reader = new TdmsReader(stream);
+            return reader.ReadFile();
+        }
+    }
+}

--- a/TDMSSharp/TdmsProperty.cs
+++ b/TDMSSharp/TdmsProperty.cs
@@ -1,0 +1,16 @@
+namespace TDMSSharp
+{
+    public class TdmsProperty
+    {
+        public string Name { get; }
+        public TdsDataType DataType { get; }
+        public object Value { get; }
+
+        public TdmsProperty(string name, TdsDataType dataType, object value)
+        {
+            Name = name;
+            DataType = dataType;
+            Value = value;
+        }
+    }
+}

--- a/TDMSSharp/TdmsRawDataIndex.cs
+++ b/TDMSSharp/TdmsRawDataIndex.cs
@@ -1,0 +1,16 @@
+namespace TDMSSharp
+{
+    public class TdmsRawDataIndex
+    {
+        public TdsDataType DataType { get; }
+        public ulong NumberOfValues { get; }
+        public ulong TotalSizeInBytes { get; } // Only for string data
+
+        public TdmsRawDataIndex(TdsDataType dataType, ulong numberOfValues, ulong totalSizeInBytes = 0)
+        {
+            DataType = dataType;
+            NumberOfValues = numberOfValues;
+            TotalSizeInBytes = totalSizeInBytes;
+        }
+    }
+}

--- a/TDMSSharp/TdmsReader.cs
+++ b/TDMSSharp/TdmsReader.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using System.Text;
+
+namespace TDMSSharp
+{
+    public class TdmsReader
+    {
+        private readonly BinaryReader _reader;
+        private static readonly DateTime TdmsEpoch = new DateTime(1904, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public TdmsReader(Stream stream)
+        {
+            _reader = new BinaryReader(stream, Encoding.UTF8, true);
+        }
+
+        public TdmsFile ReadFile()
+        {
+            var file = new TdmsFile();
+            while (_reader.BaseStream.Position < _reader.BaseStream.Length)
+            {
+                ReadSegment(file);
+            }
+            return file;
+        }
+
+        private void ReadSegment(TdmsFile file)
+        {
+            var leadIn = ReadLeadIn();
+            if (leadIn == null) return;
+
+            if ((leadIn.Value.tocMask & (1 << 1)) != 0) // kTocMetaData
+            {
+                ReadMetaData(file);
+            }
+
+            // Raw data handling is still pending
+        }
+
+        private (uint tocMask, uint version, ulong nextSegmentOffset, ulong rawDataOffset)? ReadLeadIn()
+        {
+            if (_reader.BaseStream.Position + 28 > _reader.BaseStream.Length)
+                return null;
+
+            var tag = _reader.ReadBytes(4);
+            if (Encoding.ASCII.GetString(tag) != "TDSm")
+            {
+                return null;
+            }
+
+            var tocMask = _reader.ReadUInt32();
+            var version = _reader.ReadUInt32();
+            var nextSegmentOffset = _reader.ReadUInt64();
+            var rawDataOffset = _reader.ReadUInt64();
+
+            return (tocMask, version, nextSegmentOffset, rawDataOffset);
+        }
+
+        private void ReadMetaData(TdmsFile file)
+        {
+            var objectCount = _reader.ReadUInt32();
+            for (int i = 0; i < objectCount; i++)
+            {
+                var path = ReadString();
+                var pathParts = ParsePath(path);
+
+                object tdmsObject;
+
+                if (pathParts.Count == 0)
+                {
+                    tdmsObject = file;
+                }
+                else if (pathParts.Count == 1)
+                {
+                    tdmsObject = file.GetOrAddChannelGroup(path);
+                }
+                else if (pathParts.Count == 2)
+                {
+                    var groupPath = $"/'{pathParts[0]}'";
+                    var channelGroup = file.GetOrAddChannelGroup(groupPath);
+                    tdmsObject = channelGroup.GetOrAddChannel(path);
+                }
+                else
+                {
+                    throw new NotSupportedException($"Paths with more than 2 levels are not supported: {path}");
+                }
+
+                var rawDataIndexLength = _reader.ReadUInt32();
+                if (rawDataIndexLength > 0 && rawDataIndexLength != 0xFFFFFFFF)
+                {
+                    var dataType = (TdsDataType)_reader.ReadUInt32();
+                    var dimension = _reader.ReadUInt32();
+                    if (dimension != 1)
+                        throw new NotSupportedException("Only 1-dimensional arrays are supported.");
+
+                    var numberOfValues = _reader.ReadUInt64();
+
+                    if (tdmsObject is TdmsChannel channel)
+                    {
+                        channel.DataType = dataType;
+                        channel.NumberOfValues += numberOfValues;
+                    }
+
+                    if (dataType == TdsDataType.String)
+                    {
+                        var totalSizeInBytes = _reader.ReadUInt64();
+                    }
+                }
+
+                var numProperties = _reader.ReadUInt32();
+                var properties = GetPropertiesList(tdmsObject);
+
+                for (int j = 0; j < numProperties; j++)
+                {
+                    var propName = ReadString();
+                    var propDataType = (TdsDataType)_reader.ReadUInt32();
+                    var propValue = ReadValue(propDataType);
+                    properties.Add(new TdmsProperty(propName, propDataType, propValue));
+                }
+            }
+        }
+
+        private List<string> ParsePath(string path)
+        {
+            var parts = new List<string>();
+            if (string.IsNullOrEmpty(path) || path == "/") return parts;
+
+            var pathWithoutRoot = path.Substring(1);
+            var stringParts = pathWithoutRoot.Split(new[] { "'/'" }, StringSplitOptions.None);
+            foreach (var part in stringParts)
+            {
+                parts.Add(part.Trim('\'').Replace("''", "'"));
+            }
+            return parts;
+        }
+
+        private IList<TdmsProperty> GetPropertiesList(object tdmsObject)
+        {
+            if (tdmsObject is TdmsFile f) return f.Properties;
+            if (tdmsObject is TdmsChannelGroup g) return g.Properties;
+            if (tdmsObject is TdmsChannel c) return c.Properties;
+            throw new ArgumentException("Unknown TDMS object type.");
+        }
+
+        private string ReadString()
+        {
+            var length = _reader.ReadUInt32();
+            if (length == 0) return string.Empty;
+            var bytes = _reader.ReadBytes((int)length);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        private object ReadValue(TdsDataType dataType)
+        {
+            switch (dataType)
+            {
+                case TdsDataType.I8: return _reader.ReadSByte();
+                case TdsDataType.I16: return _reader.ReadInt16();
+                case TdsDataType.I32: return _reader.ReadInt32();
+                case TdsDataType.I64: return _reader.ReadInt64();
+                case TdsDataType.U8: return _reader.ReadByte();
+                case TdsDataType.U16: return _reader.ReadUInt16();
+                case TdsDataType.U32: return _reader.ReadUInt32();
+                case TdsDataType.U64: return _reader.ReadUInt64();
+                case TdsDataType.SingleFloat: return _reader.ReadSingle();
+                case TdsDataType.DoubleFloat: return _reader.ReadDouble();
+                case TdsDataType.String: return ReadString();
+                case TdsDataType.Boolean: return _reader.ReadBoolean();
+                case TdsDataType.TimeStamp:
+                    var fractions = _reader.ReadUInt64();
+                    var seconds = _reader.ReadInt64();
+                    var ticks = (long)(new BigInteger(fractions) * 10_000_000 / (BigInteger.One << 64));
+                    return TdmsEpoch.AddSeconds(seconds).AddTicks(ticks);
+                default:
+                    throw new NotSupportedException($"Data type {dataType} is not supported for properties.");
+            }
+        }
+    }
+}

--- a/TDMSSharp/TdmsSegment.cs
+++ b/TDMSSharp/TdmsSegment.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace TDMSSharp
+{
+    public class TdmsSegment
+    {
+        public long NextSegmentOffset { get; set; }
+        public long RawDataOffset { get; set; }
+        public IList<TdmsChannelGroup> ChannelGroups { get; } = new List<TdmsChannelGroup>();
+    }
+}

--- a/TDMSSharp/TdmsWriter.cs
+++ b/TDMSSharp/TdmsWriter.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace TDMSSharp
+{
+    public class TdmsWriter
+    {
+        private readonly BinaryWriter _writer;
+        private static readonly DateTime TdmsEpoch = new DateTime(1904, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public TdmsWriter(Stream stream)
+        {
+            _writer = new BinaryWriter(stream, Encoding.UTF8, true);
+        }
+
+        public void WriteFile(TdmsFile file)
+        {
+            _writer.Seek(28, SeekOrigin.Begin);
+
+            long metaDataStart = _writer.BaseStream.Position;
+            WriteMetaData(file);
+            long metaDataEnd = _writer.BaseStream.Position;
+            long metaDataLength = metaDataEnd - metaDataStart;
+
+            long rawDataStart = _writer.BaseStream.Position;
+            foreach (var group in file.ChannelGroups)
+            {
+                foreach (var channel in group.Channels)
+                {
+                    if (channel.Data != null)
+                    {
+                        WriteRawData(channel.Data);
+                    }
+                }
+            }
+            long rawDataEnd = _writer.BaseStream.Position;
+            long rawDataLength = rawDataEnd - rawDataStart;
+
+            long nextSegmentOffset = metaDataLength + rawDataLength;
+
+            _writer.Seek(0, SeekOrigin.Begin);
+
+            uint tocMask = 0;
+            tocMask |= (1 << 1); // kTocMetaData
+            if (rawDataLength > 0) tocMask |= (1 << 3); // kTocRawData
+            tocMask |= (1 << 2); // kTocNewObjList
+
+            _writer.Write(Encoding.ASCII.GetBytes("TDSm"));
+            _writer.Write(tocMask);
+            _writer.Write((uint)4713); // Version
+            _writer.Write((ulong)nextSegmentOffset);
+            _writer.Write((ulong)metaDataLength); // Raw data offset
+
+            _writer.Seek(0, SeekOrigin.End);
+        }
+
+        private void WriteMetaData(TdmsFile file)
+        {
+            uint objectCount = 1; // file
+            objectCount += (uint)file.ChannelGroups.Count;
+            foreach (var group in file.ChannelGroups)
+            {
+                objectCount += (uint)group.Channels.Count;
+            }
+            _writer.Write(objectCount);
+
+            WriteObjectMetaData("/", file.Properties);
+
+            foreach (var group in file.ChannelGroups)
+            {
+                WriteObjectMetaData(group.Path, group.Properties);
+                foreach (var channel in group.Channels)
+                {
+                    WriteObjectMetaData(channel.Path, channel.Properties, channel);
+                }
+            }
+        }
+
+        private void WriteObjectMetaData(string path, IList<TdmsProperty> properties, TdmsChannel channel = null)
+        {
+            WriteString(path);
+
+            if (channel != null && channel.NumberOfValues > 0)
+            {
+                using (var ms = new MemoryStream())
+                using (var tempWriter = new BinaryWriter(ms))
+                {
+                    tempWriter.Write((uint)channel.DataType);
+                    tempWriter.Write((uint)1); // Dimension
+                    tempWriter.Write(channel.NumberOfValues);
+                    if (channel.DataType == TdsDataType.String)
+                    {
+                        tempWriter.Write((ulong)0); // Placeholder
+                    }
+                    _writer.Write((uint)ms.Length);
+                    _writer.Write(ms.ToArray());
+                }
+            }
+            else
+            {
+                _writer.Write((uint)0xFFFFFFFF);
+            }
+
+            _writer.Write((uint)properties.Count);
+            foreach (var prop in properties)
+            {
+                WriteString(prop.Name);
+                _writer.Write((uint)prop.DataType);
+                WriteValue(prop.Value, prop.DataType);
+            }
+        }
+
+        private void WriteRawData(object data)
+        {
+            var array = (Array)data;
+            if (array.Length == 0) return;
+
+            var elementType = array.GetType().GetElementType();
+            if (elementType.IsPrimitive)
+            {
+                var elementSize = System.Runtime.InteropServices.Marshal.SizeOf(elementType);
+                var byteBuffer = new byte[array.Length * elementSize];
+                Buffer.BlockCopy(array, 0, byteBuffer, 0, byteBuffer.Length);
+                _writer.Write(byteBuffer);
+            }
+            else
+            {
+                throw new NotSupportedException("Writing raw data for non-primitive types is not supported.");
+            }
+        }
+
+        private void WriteString(string s)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s);
+            _writer.Write((uint)bytes.Length);
+            _writer.Write(bytes);
+        }
+
+        private void WriteValue(object value, TdsDataType dataType)
+        {
+            switch (dataType)
+            {
+                case TdsDataType.I8: _writer.Write((sbyte)value); break;
+                case TdsDataType.I16: _writer.Write((short)value); break;
+                case TdsDataType.I32: _writer.Write((int)value); break;
+                case TdsDataType.I64: _writer.Write((long)value); break;
+                case TdsDataType.U8: _writer.Write((byte)value); break;
+                case TdsDataType.U16: _writer.Write((ushort)value); break;
+                case TdsDataType.U32: _writer.Write((uint)value); break;
+                case TdsDataType.U64: _writer.Write((ulong)value); break;
+                case TdsDataType.SingleFloat: _writer.Write((float)value); break;
+                case TdsDataType.DoubleFloat: _writer.Write((double)value); break;
+                case TdsDataType.String: WriteString((string)value); break;
+                case TdsDataType.Boolean: _writer.Write((bool)value); break;
+                case TdsDataType.TimeStamp:
+                    var timestamp = (DateTime)value;
+                    var timespan = timestamp - TdmsEpoch;
+                    long seconds = (long)timespan.TotalSeconds;
+                    var fractions = (ulong)((timespan.Ticks % TimeSpan.TicksPerSecond) * (1.0 / TimeSpan.TicksPerSecond * (1UL << 64)));
+                    _writer.Write(fractions);
+                    _writer.Write(seconds);
+                    break;
+                default:
+                    throw new NotSupportedException($"Data type {dataType} is not supported for properties.");
+            }
+        }
+    }
+}

--- a/TDMSSharp/TdsDataType.cs
+++ b/TDMSSharp/TdsDataType.cs
@@ -1,0 +1,28 @@
+namespace TDMSSharp
+{
+    public enum TdsDataType : uint
+    {
+        Void = 0,
+        I8 = 1,
+        I16 = 2,
+        I32 = 3,
+        I64 = 4,
+        U8 = 5,
+        U16 = 6,
+        U32 = 7,
+        U64 = 8,
+        SingleFloat = 9,
+        DoubleFloat = 10,
+        ExtendedFloat = 11,
+        SingleFloatWithUnit = 0x19,
+        DoubleFloatWithUnit = 0x1A,
+        ExtendedFloatWithUnit = 0x1B,
+        String = 0x20,
+        Boolean = 0x21,
+        TimeStamp = 0x44,
+        FixedPoint = 0x4F,
+        ComplexSingleFloat = 0x08000c,
+        ComplexDoubleFloat = 0x10000d,
+        DAQmxRawData = 0xFFFFFFFF
+    }
+}

--- a/TDMSSharp/TdsDataTypeProvider.cs
+++ b/TDMSSharp/TdsDataTypeProvider.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace TDMSSharp
+{
+    public static class TdsDataTypeProvider
+    {
+        public static TdsDataType GetDataType<T>()
+        {
+            var type = typeof(T);
+            if (type == typeof(sbyte)) return TdsDataType.I8;
+            if (type == typeof(short)) return TdsDataType.I16;
+            if (type == typeof(int)) return TdsDataType.I32;
+            if (type == typeof(long)) return TdsDataType.I64;
+            if (type == typeof(byte)) return TdsDataType.U8;
+            if (type == typeof(ushort)) return TdsDataType.U16;
+            if (type == typeof(uint)) return TdsDataType.U32;
+            if (type == typeof(ulong)) return TdsDataType.U64;
+            if (type == typeof(float)) return TdsDataType.SingleFloat;
+            if (type == typeof(double)) return TdsDataType.DoubleFloat;
+            if (type == typeof(string)) return TdsDataType.String;
+            if (type == typeof(bool)) return TdsDataType.Boolean;
+            if (type == typeof(DateTime)) return TdsDataType.TimeStamp;
+            throw new NotSupportedException($"The type {type.Name} is not a supported TDMS data type.");
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the initial implementation of the TDMS# library, a C# library for working with TDMS files.

The implementation includes:
- Core classes for representing the TDMS file structure (`TdmsFile`, `TdmsChannelGroup`, `TdmsChannel`).
- A `TdmsWriter` class that can write a `TdmsFile` object with metadata and raw data for primitive types to a stream.
- A `TdmsReader` class that can read the metadata from a TDMS file.
- A user-friendly public API for creating and saving TDMS files.
- A test project with a basic round-trip test for metadata.

Known limitations:
- The `TdmsReader` does not yet read the raw data from the channels.
- The path parsing in the reader is simplistic and may not handle all edge cases.
- The unit tests are incomplete and do not cover raw data verification.

This implementation was created based on a user request to pause development and deliver the current progress.