### PR TITLE
Fix(TDMS): Enable property writing in TdmsFileStream

### DIFF
--- a/TDMSSharp.Tests/IncrementalWriterTests.cs
+++ b/TDMSSharp.Tests/IncrementalWriterTests.cs
@@ -41,5 +41,37 @@ namespace TDMSSharp.Tests
             var data2 = ((TdmsChannel<double>)channel2).Data;
             Assert.Equal(new[] { 3.14 }, data2);
         }
+
+        [Fact]
+        public void WriteAndRead_IncrementalFile_WithProperties_ShouldMatch()
+        {
+            var path = Path.GetTempFileName();
+            using (var fileStream = new TdmsFileStream(path))
+            {
+                fileStream.AddFileProperty("File_Property", "File_Value");
+                fileStream.AppendData("group1", "channel1", new[] { 1, 2, 3 });
+                fileStream.AddGroupProperty("group1", "Group_Property", "Group_Value");
+                fileStream.AddChannelProperty("group1", "channel1", "Channel_Property", "Channel_Value");
+                fileStream.AppendData("group1", "channel1", new[] { 4, 5, 6 });
+            }
+
+            var file = TdmsFile.Open(path);
+
+            Assert.Single(file.Properties);
+            Assert.Equal("File_Property", file.Properties[0].Name);
+            Assert.Equal("File_Value", file.Properties[0].Value);
+
+            Assert.Single(file.ChannelGroups);
+            var group1 = file.ChannelGroups[0];
+            Assert.Single(group1.Properties);
+            Assert.Equal("Group_Property", group1.Properties[0].Name);
+            Assert.Equal("Group_Value", group1.Properties[0].Value);
+
+            Assert.Single(group1.Channels);
+            var channel1 = group1.Channels[0];
+            Assert.Single(channel1.Properties);
+            Assert.Equal("Channel_Property", channel1.Properties[0].Name);
+            Assert.Equal("Channel_Value", channel1.Properties[0].Value);
+        }
     }
 }

--- a/TDMSSharp/StreamingTdmsWriter.cs
+++ b/TDMSSharp/StreamingTdmsWriter.cs
@@ -19,8 +19,53 @@ namespace TDMSSharp
             _file = file;
         }
 
+        public void WriteFileHeader()
+        {
+            if (_writer.BaseStream.Position == 0 && _file.Properties.Count == 0 && _file.ChannelGroups.Count == 0) return;
+
+            long currentSegmentLeadInStart = _writer.BaseStream.Position;
+
+            // Reserve space for lead-in
+            long leadInPosition = _writer.BaseStream.Position;
+            _writer.Write(new byte[28]);
+
+            long metaDataStart = _writer.BaseStream.Position;
+            WriteAllMetaData(_writer);
+            long metaDataLength = _writer.BaseStream.Position - metaDataStart;
+
+            // Update previous segment's next offset
+            if (_previousSegmentLeadInStart != -1)
+            {
+                long currentPos = _writer.BaseStream.Position;
+                _writer.BaseStream.Seek(_previousSegmentLeadInStart + 12, SeekOrigin.Begin);
+                _writer.Write((ulong)(currentSegmentLeadInStart - (_previousSegmentLeadInStart + 28)));
+                _writer.BaseStream.Seek(currentPos, SeekOrigin.Begin);
+            }
+
+            // Write lead-in at reserved position
+            long endPosition = _writer.BaseStream.Position;
+            _writer.BaseStream.Seek(leadInPosition, SeekOrigin.Begin);
+
+            uint tocMask = (1 << 1) | (1 << 2); // Meta data and New object list
+
+            _writer.Write(Encoding.ASCII.GetBytes("TDSm"));
+            _writer.Write(tocMask);
+            _writer.Write((uint)4713);
+            _writer.Write((ulong)metaDataLength); // Segment length
+            _writer.Write((ulong)metaDataLength); // Meta data length
+
+            _writer.BaseStream.Seek(endPosition, SeekOrigin.Begin);
+            _writer.Flush();
+
+            _previousSegmentLeadInStart = currentSegmentLeadInStart;
+        }
+
+        public bool MetadataDirty { get; set; }
+
         public void WriteSegment(TdmsChannel[] channels, object[] dataArrays)
         {
+            if (MetadataDirty) WriteMetadataSegment();
+
             long currentSegmentLeadInStart = _writer.BaseStream.Position;
 
             var valueCounts = new Dictionary<TdmsChannel, ulong>();
@@ -54,11 +99,7 @@ namespace TDMSSharp
             {
                 long currentPos = _writer.BaseStream.Position;
                 _writer.BaseStream.Seek(_previousSegmentLeadInStart + 12, SeekOrigin.Begin);
-
-                long previousSegmentEnd = _previousSegmentLeadInStart + 28;
-                long offsetToNextSegment = currentSegmentLeadInStart - previousSegmentEnd;
-                _writer.Write((ulong)offsetToNextSegment);
-
+                _writer.Write((ulong)(currentSegmentLeadInStart - (_previousSegmentLeadInStart + 28)));
                 _writer.BaseStream.Seek(currentPos, SeekOrigin.Begin);
             }
 
@@ -82,40 +123,16 @@ namespace TDMSSharp
             _previousSegmentLeadInStart = currentSegmentLeadInStart;
         }
 
-        private bool WriteMetaData(BinaryWriter writer, TdmsChannel[] channels, Dictionary<TdmsChannel, ulong> valueCounts)
+        private void WriteAllMetaData(BinaryWriter writer)
         {
-            var objectsToWrite = new List<object>();
-            bool newObjects = false;
-            
-            if (_writtenObjects.Count == 0)
-            {
-                objectsToWrite.Add(_file);
-                _writtenObjects.Add("/");
-            }
+            var objects = new List<object> { _file };
+            objects.AddRange(_file.ChannelGroups);
+            foreach (var group in _file.ChannelGroups)
+                objects.AddRange(group.Channels);
 
-            foreach (var channel in channels)
-            {
-                var groupName = GetGroupName(channel.Path);
-                var groupPath = $"/'{groupName}'";
+            writer.Write((uint)objects.Count);
 
-                if (!_writtenObjects.Contains(groupPath))
-                {
-                    var group = _file.GetOrAddChannelGroup(groupName);
-                    objectsToWrite.Add(group);
-                    _writtenObjects.Add(groupPath);
-                    newObjects = true;
-                }
-                if (!_writtenObjects.Contains(channel.Path))
-                {
-                    newObjects = true;
-                    _writtenObjects.Add(channel.Path);
-                }
-                objectsToWrite.Add(channel);
-            }
-
-            writer.Write((uint)objectsToWrite.Count);
-
-            foreach (var obj in objectsToWrite)
+            foreach (var obj in objects)
             {
                 if (obj is TdmsFile file)
                 {
@@ -127,32 +144,172 @@ namespace TDMSSharp
                 }
                 else if (obj is TdmsChannel channel)
                 {
-                    TdmsWriter.WriteString(writer, channel.Path);
+                    TdmsWriter.WriteObjectMetaData(writer, channel.Path, channel.Properties, channel, 0);
+                }
+            }
+            _writtenObjects.Clear();
+            _writtenObjects.Add("/");
+            foreach (var group in _file.ChannelGroups) _writtenObjects.Add(group.Path);
+            foreach (var group in _file.ChannelGroups)
+                foreach (var channel in group.Channels) _writtenObjects.Add(channel.Path);
+        }
 
-                    var currentIndex = new TdmsRawDataIndex(channel.DataType, valueCounts[channel]);
+        private TdmsFile _lastWrittenState = new TdmsFile();
 
-                    // Check if index matches previous segment
-                    if (_channelIndices.TryGetValue(channel.Path, out var previousIndex) &&
-                        previousIndex.DataType == currentIndex.DataType &&
-                        previousIndex.NumberOfValues == currentIndex.NumberOfValues)
+        private void WriteMetadataSegment()
+        {
+            long currentSegmentLeadInStart = _writer.BaseStream.Position;
+
+            // Reserve space for lead-in
+            long leadInPosition = _writer.BaseStream.Position;
+            _writer.Write(new byte[28]);
+
+            long metaDataStart = _writer.BaseStream.Position;
+
+            var changedObjects = new List<object>();
+
+            var lastWrittenFileProps = _lastWrittenState.Properties.ToDictionary(p => p.Name);
+            var currentFileProps = _file.Properties.Where(p => !lastWrittenFileProps.ContainsKey(p.Name) || !p.Equals(lastWrittenFileProps[p.Name])).ToList();
+            if (currentFileProps.Any())
+            {
+                var file = new TdmsFile();
+                foreach(var p in currentFileProps) file.Properties.Add(p);
+                changedObjects.Add(file);
+            }
+
+            var lastWrittenGroups = _lastWrittenState.ChannelGroups.ToDictionary(g => g.Path);
+            foreach (var group in _file.ChannelGroups)
+            {
+                if (!lastWrittenGroups.TryGetValue(group.Path, out var lastWrittenGroup))
+                {
+                    changedObjects.Add(group);
+                }
+                else
+                {
+                    var lastWrittenGroupProps = lastWrittenGroup.Properties.ToDictionary(p => p.Name);
+                    var currentGroupProps = group.Properties.Where(p => !lastWrittenGroupProps.ContainsKey(p.Name) || !p.Equals(lastWrittenGroupProps[p.Name])).ToList();
+                    if (currentGroupProps.Any())
                     {
-                        writer.Write((uint)0x00000000);
-                    }
-                    else
-                    {
-                        WriteRawDataIndex(writer, channel, valueCounts[channel]);
-                        _channelIndices[channel.Path] = currentIndex;
+                        var newGroup = new TdmsChannelGroup(group.Path);
+                        foreach(var p in currentGroupProps) newGroup.Properties.Add(p);
+                        changedObjects.Add(newGroup);
                     }
 
-                    // Write properties
-                    writer.Write((uint)channel.Properties.Count);
-                    foreach (var prop in channel.Properties)
+                    var lastWrittenChannels = lastWrittenGroup.Channels.ToDictionary(c => c.Path);
+                    foreach (var channel in group.Channels)
                     {
-                        TdmsWriter.WriteString(writer, prop.Name);
-                        writer.Write((uint)prop.DataType);
-                        if (prop.Value != null)
-                            TdmsWriter.WriteValue(writer, prop.Value, prop.DataType);
+                        if (!lastWrittenChannels.TryGetValue(channel.Path, out var lastWrittenChannel))
+                        {
+                            changedObjects.Add(channel);
+                        }
+                        else
+                        {
+                            var lastWrittenChannelProps = lastWrittenChannel.Properties.ToDictionary(p => p.Name);
+                            var currentChannelProps = channel.Properties.Where(p => !lastWrittenChannelProps.ContainsKey(p.Name) || !p.Equals(lastWrittenChannelProps[p.Name])).ToList();
+                            if (currentChannelProps.Any())
+                            {
+                                var newChannel = new TdmsChannel(channel.Path) { DataType = channel.DataType };
+                                foreach(var p in currentChannelProps) newChannel.Properties.Add(p);
+                                changedObjects.Add(newChannel);
+                            }
+                        }
                     }
+                }
+            }
+
+            _writer.Write((uint)changedObjects.Count);
+            foreach(var o in changedObjects)
+            {
+                if (o is TdmsFile f) TdmsWriter.WriteObjectMetaData(_writer, "/", f.Properties);
+                else if (o is TdmsChannelGroup g) TdmsWriter.WriteObjectMetaData(_writer, g.Path, g.Properties);
+                else if (o is TdmsChannel c) TdmsWriter.WriteObjectMetaData(_writer, c.Path, c.Properties, c, 0);
+            }
+
+            _lastWrittenState = _file.DeepClone();
+
+            long metaDataLength = _writer.BaseStream.Position - metaDataStart;
+
+            // Update previous segment's next offset
+            if (_previousSegmentLeadInStart != -1)
+            {
+                long currentPos = _writer.BaseStream.Position;
+                _writer.BaseStream.Seek(_previousSegmentLeadInStart + 12, SeekOrigin.Begin);
+                _writer.Write((ulong)(currentSegmentLeadInStart - (_previousSegmentLeadInStart + 28)));
+                _writer.BaseStream.Seek(currentPos, SeekOrigin.Begin);
+            }
+
+            // Write lead-in at reserved position
+            long endPosition = _writer.BaseStream.Position;
+            _writer.BaseStream.Seek(leadInPosition, SeekOrigin.Begin);
+
+            uint tocMask = (1 << 1) | (1 << 2); // Meta data and New object list
+
+            _writer.Write(Encoding.ASCII.GetBytes("TDSm"));
+            _writer.Write(tocMask);
+            _writer.Write((uint)4713);
+            _writer.Write((ulong)metaDataLength); // Segment length
+            _writer.Write((ulong)metaDataLength); // Meta data length
+
+            _writer.BaseStream.Seek(endPosition, SeekOrigin.Begin);
+            _writer.Flush();
+
+            _previousSegmentLeadInStart = currentSegmentLeadInStart;
+            MetadataDirty = false;
+            _writtenObjects.Clear();
+            _writtenObjects.Add("/");
+            foreach(var g in _file.ChannelGroups) _writtenObjects.Add(g.Path);
+            foreach(var g in _file.ChannelGroups)
+                foreach(var c in g.Channels) _writtenObjects.Add(c.Path);
+        }
+
+        private bool WriteMetaData(BinaryWriter writer, TdmsChannel[] channels, Dictionary<TdmsChannel, ulong> valueCounts)
+        {
+            var objectsToWrite = new List<object>();
+            bool newObjects = false;
+
+            if (!_writtenObjects.Contains("/"))
+            {
+                objectsToWrite.Add(_file);
+                newObjects = true;
+            }
+
+            foreach (var channel in channels)
+            {
+                var groupName = GetGroupName(channel.Path);
+                var groupPath = $"/'{groupName}'";
+
+                if (!_writtenObjects.Contains(groupPath))
+                {
+                    var group = _file.GetOrAddChannelGroup(groupName);
+                    objectsToWrite.Add(group);
+                    newObjects = true;
+                }
+
+                objectsToWrite.Add(channel);
+                if (!_writtenObjects.Contains(channel.Path))
+                {
+                    newObjects = true;
+                }
+            }
+
+            writer.Write((uint)objectsToWrite.Count);
+
+            foreach (var obj in objectsToWrite)
+            {
+                if (obj is TdmsFile file)
+                {
+                    TdmsWriter.WriteObjectMetaData(writer, "/", file.Properties);
+                    _writtenObjects.Add("/");
+                }
+                else if (obj is TdmsChannelGroup group)
+                {
+                    TdmsWriter.WriteObjectMetaData(writer, group.Path, group.Properties);
+                    _writtenObjects.Add(group.Path);
+                }
+                else if (obj is TdmsChannel channel)
+                {
+                    TdmsWriter.WriteObjectMetaData(writer, channel.Path, channel.Properties, channel, valueCounts[channel]);
+                    _writtenObjects.Add(channel.Path);
                 }
             }
 

--- a/TDMSSharp/TdmsChannel.cs
+++ b/TDMSSharp/TdmsChannel.cs
@@ -37,5 +37,19 @@ namespace TDMSSharp
         {
             return Data as Array;
         }
+
+        public TdmsChannel DeepClone()
+        {
+            var clone = new TdmsChannel(Path)
+            {
+                DataType = DataType,
+                NumberOfValues = NumberOfValues
+            };
+            foreach (var prop in Properties)
+            {
+                clone.Properties.Add(new TdmsProperty(prop.Name, prop.DataType, prop.Value));
+            }
+            return clone;
+        }
     }
 }

--- a/TDMSSharp/TdmsChannelGroup.cs
+++ b/TDMSSharp/TdmsChannelGroup.cs
@@ -35,5 +35,19 @@ namespace TDMSSharp
             var dataType = TdsDataTypeProvider.GetDataType<T>();
             Properties.Add(new TdmsProperty(name, dataType, value));
         }
+
+        public TdmsChannelGroup DeepClone()
+        {
+            var clone = new TdmsChannelGroup(Path);
+            foreach (var prop in Properties)
+            {
+                clone.Properties.Add(new TdmsProperty(prop.Name, prop.DataType, prop.Value));
+            }
+            foreach (var channel in Channels)
+            {
+                clone.Channels.Add(channel.DeepClone());
+            }
+            return clone;
+        }
     }
 }

--- a/TDMSSharp/TdmsFile.cs
+++ b/TDMSSharp/TdmsFile.cs
@@ -59,5 +59,19 @@ namespace TDMSSharp
             var reader = new TdmsReader(stream);
             return reader.ReadFile();
         }
+
+        public TdmsFile DeepClone()
+        {
+            var clone = new TdmsFile();
+            foreach (var prop in Properties)
+            {
+                clone.Properties.Add(new TdmsProperty(prop.Name, prop.DataType, prop.Value));
+            }
+            foreach (var group in ChannelGroups)
+            {
+                clone.ChannelGroups.Add(group.DeepClone());
+            }
+            return clone;
+        }
     }
 }

--- a/TDMSSharp/TdmsFileStream.cs
+++ b/TDMSSharp/TdmsFileStream.cs
@@ -115,6 +115,7 @@ namespace TDMSSharp
         public void AddFileProperty<T>(string name, T value)
         {
             _file.AddProperty(name, value);
+            _writer.MetadataDirty = true;
         }
 
         /// <summary>
@@ -124,6 +125,7 @@ namespace TDMSSharp
         {
             var group = _file.GetOrAddChannelGroup(groupName);
             group.AddProperty(propertyName, value);
+            _writer.MetadataDirty = true;
         }
 
         /// <summary>
@@ -143,6 +145,7 @@ namespace TDMSSharp
             }
             
             channel.AddProperty(propertyName, value);
+            _writer.MetadataDirty = true;
         }
 
         /// <summary>

--- a/TDMSSharp/TdmsProperty.cs
+++ b/TDMSSharp/TdmsProperty.cs
@@ -12,5 +12,16 @@ namespace TDMSSharp
             DataType = dataType;
             Value = value;
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TdmsProperty other)
+            {
+                return Name == other.Name && DataType == other.DataType && Value.Equals(other.Value);
+            }
+            return false;
+        }
+
+        public override int GetHashCode() => (Name, DataType, Value).GetHashCode();
     }
 }

--- a/TDMSSharp/TdmsReader.cs
+++ b/TDMSSharp/TdmsReader.cs
@@ -640,6 +640,11 @@ namespace TDMSSharp
                 var propName = ReadStringOptimized();
                 var propDataType = (TdsDataType)_reader.ReadUInt32();
                 var propValue = ReadValue(propDataType);
+                var existingProp = properties.FirstOrDefault(p => p.Name == propName);
+                if (existingProp != null)
+                {
+                    properties.Remove(existingProp);
+                }
                 properties.Add(new TdmsProperty(propName, propDataType, propValue));
             }
         }


### PR DESCRIPTION
This commit fixes an issue where properties added to a TDMS file via the `TdmsFileStream` API were not being correctly written to disk, especially after the first data segment was written.

The solution involves the following changes:

1.  **Incremental Metadata Writing:** The `StreamingTdmsWriter` now tracks changes to metadata (properties of the file, groups, and channels). When a property is added or changed, a `MetadataDirty` flag is set.
2.  **Metadata Segments:** Before writing a new data segment, the writer checks the dirty flag. If true, it writes a new, metadata-only segment to the file. This segment contains only the metadata that has changed since the last write.
3.  **State Tracking:** To identify changed metadata, the writer now keeps a deep clone of the `TdmsFile` object's structure (`_lastWrittenState`) and compares it against the current state before writing.
4.  **Reader Fix:** The `TdmsReader` has been updated to correctly handle files with multiple metadata segments. It now overwrites existing properties with new values found in later segments, which is the correct behavior according to the TDMS file format specification.
5.  **New Test:** A new unit test has been added to `IncrementalWriterTests` to verify that properties can be added to the file, groups, and channels at various points during a streaming write and are persisted correctly.